### PR TITLE
Import from django.conf.urls instead of deprecated django.conf.urls.defaults

### DIFF
--- a/django_quickblocks/stories/urls.py
+++ b/django_quickblocks/stories/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from .views import *
 
 urlpatterns = patterns('',


### PR DESCRIPTION
This maintains django>=1.4 compatibility. Unfortunately the tests seem not to be up to date, so was not able to run them.
